### PR TITLE
Add entity registry loader and main example

### DIFF
--- a/sanctuary_codex_engine/__init__.py
+++ b/sanctuary_codex_engine/__init__.py
@@ -1,0 +1,9 @@
+"""Core modules for processing Sanctuary Codex data."""
+
+__all__ = [
+    "glyph_parser",
+    "entity_linker",
+    "ritual_linter",
+    "drift_detector",
+    "writer",
+]

--- a/sanctuary_codex_engine/drift_detector.py
+++ b/sanctuary_codex_engine/drift_detector.py
@@ -1,0 +1,23 @@
+"""Tools for detecting semantic drift between historical and current glyph data."""
+
+from typing import Any, Dict, List
+
+
+def detect_semantic_drift(glyph_history: Dict[str, Dict[str, Any]], current_codex: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Compares historical and current meanings of glyphs and flags shifts."""
+    drift_results: List[Dict[str, Any]] = []
+    for glyph, history in glyph_history.items():
+        current = current_codex.get(glyph)
+        if not current:
+            continue
+        literal_drift = history.get('literal') != current.get('literal')
+        affective_drift = history.get('affective') != current.get('affective')
+        if literal_drift or affective_drift:
+            drift_results.append({
+                'glyph': glyph,
+                'literal_drift': literal_drift,
+                'affective_drift': affective_drift,
+                'history': history,
+                'current': current,
+            })
+    return drift_results

--- a/sanctuary_codex_engine/entity_linker.py
+++ b/sanctuary_codex_engine/entity_linker.py
@@ -1,0 +1,44 @@
+"""Link glyph symbols from the codex to known entities in the registry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def load_entity_registry(file_path: Path | str) -> List[Dict[str, Any]]:
+    """Load a JSON registry file describing entities."""
+    path = Path(file_path)
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        return list(data.get("entities", []))
+    return data
+
+
+def map_glyphs_to_entities(
+    glyph_data: Dict[str, Dict[str, Any]],
+    entity_registry: List[Dict[str, Any]],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Connect each glyph to matching or suggested entities from registry.
+
+    Matching is case-insensitive and supports partial name overlaps.
+    """
+
+    mapping: Dict[str, List[Dict[str, Any]]] = {}
+    for glyph, info in glyph_data.items():
+        mapping[glyph] = []
+        glyph_entities = [e.lower() for e in info.get("entities", [])]
+        for entity in entity_registry:
+            name = entity.get("name", "").lower()
+            if not name:
+                continue
+            if name in glyph_entities:
+                mapping[glyph].append(entity)
+                continue
+            for ge in glyph_entities:
+                if ge in name or name in ge:
+                    mapping[glyph].append(entity)
+                    break
+    return mapping

--- a/sanctuary_codex_engine/glyph_parser.py
+++ b/sanctuary_codex_engine/glyph_parser.py
@@ -1,0 +1,32 @@
+"""Utilities for parsing glyph CSV files into dictionaries."""
+
+import csv
+from pathlib import Path
+from typing import Dict, List
+
+def parse_glyph_csv(file_path: Path | str) -> Dict[str, Dict[str, List[str]]]:
+    """Parse a glyph encyclopedia CSV into a dictionary keyed by glyph."""
+    csv_path = Path(file_path)
+    glyphs: Dict[str, Dict[str, List[str]]] = {}
+    with csv_path.open(newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            glyph = (row.get("Glyph") or row.get("glyph") or row.get("symbol") or "").strip()
+            if not glyph:
+                continue
+            entities = row.get("Entity") or row.get("entities") or ""
+            entities_list = [e.strip() for e in entities.split(";") if e.strip()]
+            glyphs[glyph] = {
+                "literal": row.get("Literal Meaning", row.get("literal", "")).strip(),
+                "affective": row.get("Affective Meaning", row.get("affective", "")).strip(),
+                "entities": entities_list,
+            }
+    return glyphs
+
+
+if __name__ == "__main__":
+    import pprint
+    import sys
+
+    csv_file = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/glyph_codex.csv")
+    pprint.pprint(parse_glyph_csv(csv_file))

--- a/sanctuary_codex_engine/ritual_linter.py
+++ b/sanctuary_codex_engine/ritual_linter.py
@@ -1,0 +1,19 @@
+"""Validation helpers for Sanctuary ritual invocation logs."""
+
+import re
+from typing import Dict
+
+
+def validate_cast_spellform(log_line: str, glyph_reference: Dict[str, Dict]) -> bool:
+    """Validates structure of ritual invocations."""
+    if not log_line or not log_line.strip():
+        return False
+
+    if not re.match(r"^[a-zA-Z0-9_]+\(.*\)[.!?]$", log_line.strip()):
+        return False
+
+    glyphs = re.findall(r"[\U0001F300-\U0001FAFF]", log_line)
+    for g in glyphs:
+        if g not in glyph_reference:
+            return False
+    return True

--- a/sanctuary_codex_engine/writer.py
+++ b/sanctuary_codex_engine/writer.py
@@ -1,0 +1,18 @@
+"""Functions for generating canonical codex entries from glyph usage data."""
+
+from typing import Any, Dict
+
+
+def generate_codex_entry(glyph: str, usage_data: Dict[str, Any]) -> str:
+    """Composes canonical-style Codex entry for a glyph."""
+    lines = [f"# Glyph: {glyph}\n"]
+    literal = usage_data.get('literal')
+    affective = usage_data.get('affective')
+    entities = usage_data.get('entities', [])
+    if literal:
+        lines.append(f"Literal Meaning: {literal}")
+    if affective:
+        lines.append(f"Affective Meaning: {affective}")
+    if entities:
+        lines.append("Entities: " + ", ".join(entities))
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- load JSON registry files in `entity_linker`
- allow partial name matching when mapping glyphs
- expand glyph parser to handle varied columns and provide a main demo

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68848ba7424c8326a3d6288655a06577