### PR TITLE
Extend codex engine with query and log modules

### DIFF
--- a/sanctuary_codex_engine/__init__.py
+++ b/sanctuary_codex_engine/__init__.py
@@ -1,0 +1,13 @@
+"""Core modules for processing Sanctuary Codex data."""
+
+__all__ = [
+    "glyph_parser",
+    "entity_linker",
+    "ritual_linter",
+    "drift_detector",
+    "codex_query",
+    "glyphchain",
+    "ritual_log_ingestor",
+    "writer",
+]
+

--- a/sanctuary_codex_engine/codex_query.py
+++ b/sanctuary_codex_engine/codex_query.py
@@ -1,0 +1,43 @@
+"""Simple query utilities for the Sanctuary Codex engine."""
+
+from typing import Any, Dict, Iterable, List
+
+
+def entities_for_glyph(glyph: str, glyph_data: Dict[str, Dict[str, Any]]) -> List[str]:
+    """Return entity names associated with a glyph from the codex."""
+    info = glyph_data.get(glyph, {})
+    return info.get("entities", [])
+
+
+def glyphs_for_entity(entity: str, glyph_data: Dict[str, Dict[str, Any]]) -> List[str]:
+    """Return glyphs that reference the given entity name (case-insensitive)."""
+    results = []
+    lowered = entity.lower()
+    for glyph, info in glyph_data.items():
+        entities = [e.lower() for e in info.get("entities", [])]
+        if any(lowered == e or lowered in e for e in entities):
+            results.append(glyph)
+    return results
+
+
+def search_literal(term: str, glyph_data: Dict[str, Dict[str, Any]]) -> List[str]:
+    """Find glyphs whose literal meaning contains the term (case-insensitive)."""
+    results = []
+    lowered = term.lower()
+    for glyph, info in glyph_data.items():
+        literal = info.get("literal", "").lower()
+        if lowered in literal:
+            results.append(glyph)
+    return results
+
+
+if __name__ == "__main__":
+    import pprint
+    from pathlib import Path
+    from glyph_parser import parse_glyph_csv
+
+    codex = parse_glyph_csv(Path("data/glyph_codex.csv"))
+    pprint.pprint(entities_for_glyph("🜏", codex))
+    pprint.pprint(glyphs_for_entity("Finalis", codex))
+    pprint.pprint(search_literal("Pain", codex))
+

--- a/sanctuary_codex_engine/drift_detector.py
+++ b/sanctuary_codex_engine/drift_detector.py
@@ -1,0 +1,23 @@
+"""Tools for detecting semantic drift between historical and current glyph data."""
+
+from typing import Any, Dict, List
+
+
+def detect_semantic_drift(glyph_history: Dict[str, Dict[str, Any]], current_codex: Dict[str, Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Compares historical and current meanings of glyphs and flags shifts."""
+    drift_results: List[Dict[str, Any]] = []
+    for glyph, history in glyph_history.items():
+        current = current_codex.get(glyph)
+        if not current:
+            continue
+        literal_drift = history.get('literal') != current.get('literal')
+        affective_drift = history.get('affective') != current.get('affective')
+        if literal_drift or affective_drift:
+            drift_results.append({
+                'glyph': glyph,
+                'literal_drift': literal_drift,
+                'affective_drift': affective_drift,
+                'history': history,
+                'current': current,
+            })
+    return drift_results

--- a/sanctuary_codex_engine/entity_linker.py
+++ b/sanctuary_codex_engine/entity_linker.py
@@ -1,0 +1,44 @@
+"""Link glyph symbols from the codex to known entities in the registry."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+
+def load_entity_registry(file_path: Path | str) -> List[Dict[str, Any]]:
+    """Load a JSON registry file describing entities."""
+    path = Path(file_path)
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+    if isinstance(data, dict):
+        return list(data.get("entities", []))
+    return data
+
+
+def map_glyphs_to_entities(
+    glyph_data: Dict[str, Dict[str, Any]],
+    entity_registry: List[Dict[str, Any]],
+) -> Dict[str, List[Dict[str, Any]]]:
+    """Connect each glyph to matching or suggested entities from registry.
+
+    Matching is case-insensitive and supports partial name overlaps.
+    """
+
+    mapping: Dict[str, List[Dict[str, Any]]] = {}
+    for glyph, info in glyph_data.items():
+        mapping[glyph] = []
+        glyph_entities = [e.lower() for e in info.get("entities", [])]
+        for entity in entity_registry:
+            name = entity.get("name", "").lower()
+            if not name:
+                continue
+            if name in glyph_entities:
+                mapping[glyph].append(entity)
+                continue
+            for ge in glyph_entities:
+                if ge in name or name in ge:
+                    mapping[glyph].append(entity)
+                    break
+    return mapping

--- a/sanctuary_codex_engine/glyph_parser.py
+++ b/sanctuary_codex_engine/glyph_parser.py
@@ -1,0 +1,32 @@
+"""Utilities for parsing glyph CSV files into dictionaries."""
+
+import csv
+from pathlib import Path
+from typing import Dict, List
+
+def parse_glyph_csv(file_path: Path | str) -> Dict[str, Dict[str, List[str]]]:
+    """Parse a glyph encyclopedia CSV into a dictionary keyed by glyph."""
+    csv_path = Path(file_path)
+    glyphs: Dict[str, Dict[str, List[str]]] = {}
+    with csv_path.open(newline="", encoding="utf-8") as csvfile:
+        reader = csv.DictReader(csvfile)
+        for row in reader:
+            glyph = (row.get("Glyph") or row.get("glyph") or row.get("symbol") or "").strip()
+            if not glyph:
+                continue
+            entities = row.get("Entity") or row.get("entities") or ""
+            entities_list = [e.strip() for e in entities.split(";") if e.strip()]
+            glyphs[glyph] = {
+                "literal": row.get("Literal Meaning", row.get("literal", "")).strip(),
+                "affective": row.get("Affective Meaning", row.get("affective", "")).strip(),
+                "entities": entities_list,
+            }
+    return glyphs
+
+
+if __name__ == "__main__":
+    import pprint
+    import sys
+
+    csv_file = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("data/glyph_codex.csv")
+    pprint.pprint(parse_glyph_csv(csv_file))

--- a/sanctuary_codex_engine/glyphchain.py
+++ b/sanctuary_codex_engine/glyphchain.py
@@ -1,0 +1,33 @@
+"""Utilities for parsing and scoring glyphchains."""
+
+from typing import Dict, List
+
+import re
+
+GLYPH_RE = re.compile(r"[🀀-🫿☀-⛿⸀-⹿ἰ0-ὟF]+")
+
+
+def parse_chain(text: str) -> List[str]:
+    """Extract glyphs from a glyphchain string."""
+    return GLYPH_RE.findall(text)
+
+
+def score_chain(glyphs: List[str], known_glyphs: Dict[str, Dict]) -> float:
+    """Score a glyphchain by fraction of glyphs present in the codex."""
+    if not glyphs:
+        return 0.0
+    known = sum(1 for g in glyphs if g in known_glyphs)
+    return known / len(glyphs)
+
+
+if __name__ == "__main__":
+    from pathlib import Path
+    from glyph_parser import parse_glyph_csv
+    import pprint
+
+    codex = parse_glyph_csv(Path("data/glyph_codex.csv"))
+    sample = "🜏⛨₻⛃🜃✧🝇🜂⛨"
+    glyphs = parse_chain(sample)
+    pprint.pprint(glyphs)
+    print(score_chain(glyphs, codex))
+

--- a/sanctuary_codex_engine/ritual_linter.py
+++ b/sanctuary_codex_engine/ritual_linter.py
@@ -1,0 +1,45 @@
+"""
+ritual_linter.py
+
+Validates Sanctuary ritual spellforms like `cast()` and `witness()`.
+Checks glyphchain structure, spellform syntax, and codex integrity.
+"""
+
+import re
+
+
+def is_valid_spellform(spellform: str) -> bool:
+    return any(spellform.startswith(kw) for kw in ("cast(", "witness(", "relay(")) and spellform.endswith(")")
+
+
+def extract_glyphchain(spellform: str) -> list:
+    match = re.search(r'\((.*?)\)', spellform)
+    if not match:
+        return []
+    content = match.group(1)
+    return [glyph.strip() for glyph in re.findall(r'[🀀-🫿☀-⛿⸀-⹿ἰ0-ὟF]+', content)]
+
+
+def lint_spellform(spellform: str, known_glyphs: dict) -> dict:
+    if not is_valid_spellform(spellform):
+        return {'valid': False, 'error': 'Malformed spellform'}
+
+    glyphs = extract_glyphchain(spellform)
+    unknown = [g for g in glyphs if g not in known_glyphs]
+
+    return {
+        'valid': len(unknown) == 0,
+        'spellform': spellform,
+        'glyphs': glyphs,
+        'unknown_glyphs': unknown
+    }
+
+
+if __name__ == "__main__":
+    from glyph_parser import parse_glyph_csv
+    import pprint
+
+    known = parse_glyph_csv("data/glyph_codex.csv")
+    example = "cast(🜏⛨₻⛃🜃✧🝇🜂⛨)"
+    result = lint_spellform(example, known)
+    pprint.pprint(result)

--- a/sanctuary_codex_engine/ritual_log_ingestor.py
+++ b/sanctuary_codex_engine/ritual_log_ingestor.py
@@ -1,0 +1,39 @@
+"""Ingest and index ritual log files for the Sanctuary Codex engine."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+
+def load_logs(paths: Iterable[Path | str]) -> List[str]:
+    """Return a list of log lines from the given file paths."""
+    lines: List[str] = []
+    for p in paths:
+        path = Path(p)
+        if not path.exists():
+            continue
+        if path.suffix.lower() == ".json":
+            with path.open(encoding="utf-8") as f:
+                data = json.load(f)
+                if isinstance(data, list):
+                    lines.extend(str(entry) for entry in data)
+                else:
+                    lines.append(str(data))
+        else:
+            with path.open(encoding="utf-8") as f:
+                lines.extend(l.strip() for l in f if l.strip())
+    return lines
+
+
+def index_logs(lines: Iterable[str]) -> Dict[int, str]:
+    """Return a simple index of logs keyed by line number."""
+    return {i: line for i, line in enumerate(lines)}
+
+
+if __name__ == "__main__":
+    import pprint
+    sample_logs = load_logs(["data/sample_log.txt"])
+    pprint.pprint(index_logs(sample_logs))
+

--- a/sanctuary_codex_engine/writer.py
+++ b/sanctuary_codex_engine/writer.py
@@ -1,0 +1,18 @@
+"""Functions for generating canonical codex entries from glyph usage data."""
+
+from typing import Any, Dict
+
+
+def generate_codex_entry(glyph: str, usage_data: Dict[str, Any]) -> str:
+    """Composes canonical-style Codex entry for a glyph."""
+    lines = [f"# Glyph: {glyph}\n"]
+    literal = usage_data.get('literal')
+    affective = usage_data.get('affective')
+    entities = usage_data.get('entities', [])
+    if literal:
+        lines.append(f"Literal Meaning: {literal}")
+    if affective:
+        lines.append(f"Affective Meaning: {affective}")
+    if entities:
+        lines.append("Entities: " + ", ".join(entities))
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- expose new modules in `__init__.py`
- implement `codex_query` helpers for looking up glyphs and entities
- add `glyphchain` utilities for parsing and scoring glyph chains
- create `ritual_log_ingestor` for loading ritual logs

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68848ba7424c8326a3d6288655a06577